### PR TITLE
Improve API key handling and script structure

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,16 +1,36 @@
 import os
-from dotenv import load_dotenv
+from pathlib import Path
+from typing import Final
+
 import assemblyai as aai
+from dotenv import load_dotenv
 
-load_dotenv()
-aai.settings.api_key = os.getenv("ASSEMBLYAI_API_KEY")
 
-transcriber = aai.Transcriber()
+def get_api_key() -> str:
+    """Return the AssemblyAI API key from the environment."""
 
-AUDIO_FILE = "dollar_drop_prediction.mp3"
+    api_key = os.getenv("ASSEMBLYAI_API_KEY")
+    if not api_key:
+        raise RuntimeError(
+            "Missing ASSEMBLYAI_API_KEY environment variable. Set it before running the script."
+        )
+    return api_key
 
-print(" Transcription en cours...")
-transcript = transcriber.transcribe(AUDIO_FILE)
 
-print("\n--- Transcription ---\n")
-print(transcript.text)
+def main() -> None:
+    load_dotenv()
+    aai.settings.api_key = get_api_key()
+
+    transcriber = aai.Transcriber()
+
+    audio_file: Final[Path] = Path("dollar_drop_prediction.mp3")
+
+    print(" Transcription en cours...")
+    transcript = transcriber.transcribe(str(audio_file))
+
+    print("\n--- Transcription ---\n")
+    print(transcript.text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- validate the AssemblyAI API key before configuring the client
- wrap the transcription logic in a main entry point and use Path for the audio file

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68d02d16de448322a82a0fb93e666fc0